### PR TITLE
Change from deprecated sort_index to sort_values

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -247,7 +247,10 @@ def get_dim_label(js_dict, dim, input="dataset"):
                                               dim_index.values())),
                                      index=dim_index.keys(),
                                      columns=['id', 'index'])
-    dim_label = pd.merge(dim_label, dim_index, on='id').sort_index(by='index')
+    if pd.__version__ <= '0.16.2':
+        dim_label = pd.merge(dim_label, dim_index, on='id').sort_index(by='index')
+    else:
+        dim_label = pd.merge(dim_label, dim_index, on='id').sort_values(by='index')
     return dim_label
 
 
@@ -280,7 +283,10 @@ def get_dim_index(js_dict, dim):
                                               dim_index.values())),
                                      index=dim_index.keys(),
                                      columns=['id', 'index'])
-    dim_index = dim_index.sort_index(by='index')
+    if pd.__version__ < '0.17':
+        dim_index = dim_index.sort_index(by='index')
+    else:
+        dim_index = dim_index.sort_values(by='index')
     return dim_index
 
 


### PR DESCRIPTION
When making a dateframe in Jupyter you get a warning that sort_index is deprecated in pandas verision >=17. Test for pandas version to set this right. 